### PR TITLE
fix: ch6 위치 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,7 +963,7 @@ src/pages/Settings.tsx
 ```typescript jsx
 ```
 
-## FCM
+## FCM[ch6]
 푸쉬알림 보내기
 - [링크](https://console.firebase.google.com/)에서 앱 만들기
 ```shell
@@ -986,7 +986,7 @@ App.tsx
 ```
 ```
 
-## 실기기 사용하기[ch6]
+## 실기기 사용하기
 [링크](https://reactnative.dev/docs/running-on-device)
 - samsung dex같은 건 끄기
 - 핸드폰 usb 연결 시 usb 디버깅 허용하기


### PR DESCRIPTION
README의 ch6가 잘못되어 있어 수정합니다!

- README ch6 위치
<img width="561" alt="image" src="https://github.com/ZeroCho/food-delivery-app/assets/66891085/5dc299a3-64aa-40d2-ac19-e19f101b56c5">

- 강의 커리큘럼 ch6 목차
<img width="399" alt="image" src="https://github.com/ZeroCho/food-delivery-app/assets/66891085/931fd184-a63f-4ce7-9391-4598de1362ce">

